### PR TITLE
Add author dashboard and course creation

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -37,9 +37,26 @@ class CourseController extends Controller
             'title' => 'required|string|max:255',
             'description' => 'nullable|string',
             'price' => 'numeric|min:0',
+            'modules' => 'array',
+            'modules.*.title' => 'required_with:modules|string|max:255',
+            'modules.*.lessons' => 'array',
+            'modules.*.lessons.*.title' => 'required_with:modules.*.lessons|string|max:255',
+            'modules.*.lessons.*.content' => 'nullable|string',
         ]);
 
+        $modules = $data['modules'] ?? [];
+        unset($data['modules']);
+
         $course = $request->user()->authoredCourses()->create($data);
+
+        foreach ($modules as $moduleData) {
+            $lessons = $moduleData['lessons'] ?? [];
+            unset($moduleData['lessons']);
+            $module = $course->modules()->create($moduleData);
+            foreach ($lessons as $lessonData) {
+                $module->lessons()->create($lessonData);
+            }
+        }
 
         return redirect()->route('courses.show', $course);
     }

--- a/resources/js/Pages/Courses/Create.vue
+++ b/resources/js/Pages/Courses/Create.vue
@@ -1,0 +1,93 @@
+<script setup>
+import { ref } from 'vue';
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head, useForm } from '@inertiajs/vue3';
+
+const form = useForm({
+    title: '',
+    description: '',
+    price: '',
+    modules: [
+        { title: '', lessons: [{ title: '', content: '' }] },
+    ],
+});
+
+function addModule() {
+    form.modules.push({ title: '', lessons: [{ title: '', content: '' }] });
+}
+
+function removeModule(index) {
+    form.modules.splice(index, 1);
+}
+
+function addLesson(moduleIndex) {
+    form.modules[moduleIndex].lessons.push({ title: '', content: '' });
+}
+
+function removeLesson(moduleIndex, lessonIndex) {
+    form.modules[moduleIndex].lessons.splice(lessonIndex, 1);
+}
+
+function submit() {
+    form.post(route('courses.store'));
+}
+</script>
+
+<template>
+    <Head title="Create Course" />
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="text-xl font-semibold leading-tight text-gray-800">
+                Create Course
+            </h2>
+        </template>
+        <div class="mx-auto max-w-4xl py-6">
+            <form @submit.prevent="submit" class="space-y-6">
+                <div>
+                    <label class="block text-sm font-medium text-gray-700">Title</label>
+                    <input v-model="form.title" type="text" class="mt-1 w-full rounded border-gray-300" />
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700">Description</label>
+                    <textarea v-model="form.description" class="mt-1 w-full rounded border-gray-300"></textarea>
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700">Price</label>
+                    <input v-model="form.price" type="number" min="0" step="0.01" class="mt-1 w-full rounded border-gray-300" />
+                </div>
+
+                <div v-for="(module, mIndex) in form.modules" :key="mIndex" class="rounded border p-4">
+                    <div class="mb-2 flex justify-between">
+                        <div class="flex-1">
+                            <label class="block text-sm font-medium text-gray-700">Module Title</label>
+                            <input v-model="module.title" type="text" class="mt-1 w-full rounded border-gray-300" />
+                        </div>
+                        <button type="button" @click="removeModule(mIndex)" class="ml-2 text-sm text-red-500">Remove</button>
+                    </div>
+
+                    <div v-for="(lesson, lIndex) in module.lessons" :key="lIndex" class="mb-4">
+                        <div class="flex justify-between">
+                            <div class="flex-1">
+                                <label class="block text-sm font-medium text-gray-700">Lesson Title</label>
+                                <input v-model="lesson.title" type="text" class="mt-1 w-full rounded border-gray-300" />
+                            </div>
+                            <button type="button" @click="removeLesson(mIndex, lIndex)" class="ml-2 text-sm text-red-500">Remove</button>
+                        </div>
+                        <div class="mt-2">
+                            <label class="block text-sm font-medium text-gray-700">Content</label>
+                            <textarea v-model="lesson.content" class="mt-1 w-full rounded border-gray-300"></textarea>
+                        </div>
+                    </div>
+
+                    <button type="button" @click="addLesson(mIndex)" class="text-sm text-blue-600">Add Lesson</button>
+                </div>
+
+                <button type="button" @click="addModule" class="text-sm text-blue-600">Add Module</button>
+
+                <div>
+                    <button type="submit" class="rounded bg-blue-600 px-4 py-2 text-white">Create</button>
+                </div>
+            </form>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/Courses/Index.vue
+++ b/resources/js/Pages/Courses/Index.vue
@@ -11,6 +11,9 @@ defineProps({ courses: Array });
             <h2 class="text-xl font-semibold leading-tight text-gray-800">Courses</h2>
         </template>
         <div class="py-6">
+            <div v-if="['author','admin'].includes($page.props.auth.user.role)" class="mb-4">
+                <Link :href="route('courses.create')" class="text-blue-600">Create Course</Link>
+            </div>
             <div v-for="course in courses" :key="course.id" class="mb-4">
                 <Link :href="route('courses.show', course.id)" class="text-blue-600">{{ course.title }}</Link>
             </div>

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -1,6 +1,7 @@
 <script setup>
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
-import { Head } from '@inertiajs/vue3';
+import { Head, Link } from '@inertiajs/vue3';
+defineProps({ courses: Array });
 </script>
 
 <template>
@@ -16,13 +17,16 @@ import { Head } from '@inertiajs/vue3';
         </template>
 
         <div class="py-12">
-            <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
-                <div
-                    class="overflow-hidden bg-white shadow-sm sm:rounded-lg"
-                >
-                    <div class="p-6 text-gray-900">
-                        You're logged in!
+            <div class="mx-auto max-w-7xl sm:px-6 lg:px-8 space-y-6">
+                <div class="overflow-hidden bg-white shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">You're logged in!</div>
+                </div>
+                <div v-if="$page.props.auth.user.role === 'author'">
+                    <h3 class="mb-2 text-lg font-semibold">My Courses</h3>
+                    <div v-for="course in courses" :key="course.id" class="mb-1">
+                        <Link :href="route('courses.show', course.id)" class="text-blue-600">{{ course.title }}</Link>
                     </div>
+                    <Link :href="route('courses.create')" class="mt-2 inline-block text-blue-600">Create new course</Link>
                 </div>
             </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,7 +15,13 @@ Route::get('/', function () {
 });
 
 Route::get('/dashboard', function () {
-    return Inertia::render('Dashboard');
+    $courses = [];
+    if (auth()->user()->role === 'author') {
+        $courses = auth()->user()->authoredCourses()->get();
+    }
+    return Inertia::render('Dashboard', [
+        'courses' => $courses,
+    ]);
 })->middleware(['auth', 'verified'])->name('dashboard');
 
 Route::middleware('auth')->group(function () {


### PR DESCRIPTION
## Summary
- allow storing modules and lessons when creating a course
- show author's courses on the dashboard
- link to new course creation page
- add new Vue page for course creation

## Testing
- `npm run build`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68772c1b4ce08328b87bf9833d28db3a