### PR TITLE
Fix admin dashboard view

### DIFF
--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -21,7 +21,7 @@ defineProps({ courses: Array });
                 <div class="overflow-hidden bg-white shadow-sm sm:rounded-lg">
                     <div class="p-6 text-gray-900">You're logged in!</div>
                 </div>
-                <div v-if="$page.props.auth.user.role === 'author'">
+                <div v-if="['author','admin'].includes($page.props.auth.user.role)">
                     <h3 class="mb-2 text-lg font-semibold">My Courses</h3>
                     <div v-for="course in courses" :key="course.id" class="mb-1">
                         <Link :href="route('courses.show', course.id)" class="text-blue-600">{{ course.title }}</Link>

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,10 +15,15 @@ Route::get('/', function () {
 });
 
 Route::get('/dashboard', function () {
+    $user = auth()->user();
     $courses = [];
-    if (auth()->user()->role === 'author') {
-        $courses = auth()->user()->authoredCourses()->get();
+
+    if ($user->role === 'author') {
+        $courses = $user->authoredCourses()->get();
+    } elseif ($user->role === 'admin') {
+        $courses = App\Models\Course::with('author')->get();
     }
+
     return Inertia::render('Dashboard', [
         'courses' => $courses,
     ]);


### PR DESCRIPTION
## Summary
- show "My Courses" section for admin users too
- show authored courses for authors and all courses for admins

## Testing
- `npm install`
- `npm run build`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6877bcbd22748328ac359407ed27094f