### PR TITLE
Fix route for authored courses

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -26,7 +26,7 @@ class CourseController extends Controller
             'title' => 'required|string|max:255',
             'description' => 'nullable|string',
         ]);
-        $course = $request->user()->coursesCreated()->create($data);
+        $course = $request->user()->authoredCourses()->create($data);
         return redirect()->route('courses.show', $course);
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -35,7 +35,7 @@ class User extends Authenticatable
         ];
     }
 
-    public function coursesCreated()
+    public function authoredCourses()
     {
         return $this->hasMany(Course::class, 'user_id');
     }


### PR DESCRIPTION
## Summary
- add the `authoredCourses` relationship on `User`
- use `authoredCourses()` when creating a course

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6878608133d8832896204dd8d720e226